### PR TITLE
Use OpenStreetMap as default map

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,8 @@
 	"showContact": false,
 	"maxAge": 14,
 	"mapLayers": [{
+		"name": "OpenStreetMap"
+	}, {
 		"name": "OpenStreetMap.BlackAndWhite"
 	}, {
 		"name": "OpenStreetMap.DE"


### PR DESCRIPTION
The OpenStreetMap.DE map is quite colorful and OpenStreetMap.BlackAndWhite has no colors at all. So make a compromise and use OpenStreetMap which is has some colors but is not too colorful.