### PR TITLE
Add Grafana user state graphs/stats

### DIFF
--- a/config.json
+++ b/config.json
@@ -35,6 +35,11 @@
         "href": "//meshviewer.chemnitz.freifunk.net/nodes/{NODE_ID}.png",
         "thumbnail": "//meshviewer.chemnitz.freifunk.net/nodes/{NODE_ID}.png",
         "caption": "Knoten {NODE_ID}"
+        },{
+        "name": "Nutzer",
+        "href": "//stats.chemnitz.freifunk.net/dashboard/db/node?var-node={NODE_ID}&from=now-24h&to=now",
+        "thumbnail": "//stats.chemnitz.freifunk.net/render/dashboard-solo/db/node?panelId=1&var-node={NODE_ID}&width=528&height=300&theme=light&from=now-25h",
+        "caption": "Für detailierten Verlauf klicken."
     }],
     "globalInfos": [{
         "name": "Wochenstatistik",


### PR DESCRIPTION
It is the new image which you can see in the FFC meshviewer under "Nutzer". For example check out https://meshviewer.chemnitz.freifunk.net/#!v:m;n:a0f3c1984ca8